### PR TITLE
* if larger than 420 pixel (the largest phones today are around 414 p…

### DIFF
--- a/src/commons/HTMLRenderer.js
+++ b/src/commons/HTMLRenderer.js
@@ -139,8 +139,8 @@ export default class HTMLRenderer extends React.Component {
                       {
                         ...htmlAttribs,
                         src: htmlAttribs.src + '?fs=0&modestbranding=1&rel=0',
-                        width: this.state.width,
-                        height: this.state.width * ar,
+                        width: this.state.width > 420 ? 420 : this.state.width,
+                        height: this.state.width > 420 ? 420 * ar : this.state.width * ar,
                       },
                       children,
                       convertedCSSStyles,


### PR DESCRIPTION
Embedded videos on iPads/Tablets are huge. This makes them smaller if the device width is larger than 420 (large modern phones are 414 pixels wide).

https://user-images.githubusercontent.com/85315241/202569838-ffa78c1f-e960-4086-a9bd-a7cd40891ce0.mp4


https://user-images.githubusercontent.com/85315241/202569868-5cd8e108-7e41-4426-8858-22e5275ec6ba.mp4

